### PR TITLE
Selector logic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-Github soft-wrap
-================
+# Github soft-wrap
 
 This is a [Greasemonkey](https://addons.mozilla.org/pt-br/firefox/addon/greasemonkey/) script that adds a "Soft wrap" button for every file and diff shown on page. This way, you can toggle soft-wrap for any type of file, either disabling soft-wrap for prose diffs (which are [enabled by default](https://github.com/blog/1707-soft-wrapping-on-prose-diffs)) or enabling them for any other diff or file.
 
-Chrome users
-------------
+## Chrome users
 
 Download the script, open Google Chrome, open the Extensions page (chrome://extensions) the drag and drop the script into the page. This will install the script without the need of any other extension.
 
-Gotcha
-------
+As an "advanced" alternative that offers more control over user scripts like this one, consider installing the [Tampermonkey](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo) extension first.
+
+## Gotcha
 
 You may need to reload the page if you navigated from another Github page. Github uses JavaScript to make navigation between pages faster, but the scripts executes on page load. Therefore, this script will only add the button on code that is already on the page when it loads.

--- a/github-soft-wrap.user.js
+++ b/github-soft-wrap.user.js
@@ -3,7 +3,8 @@
 // @namespace   http://luiz.github.io
 // @description Adds a button "Soft-wrap" that toggles soft wrap on files and diffs shown on Github
 // @author      https://github.com/luiz
-// @version     1
+// @version     1.1.0
+// @downloadUrl https://github.com/luiz/github-soft-wrap/raw/master/github-soft-wrap.user.js
 // @grant       none
 // @include     https://github.com/*
 // @match       https://github.com/*

--- a/github-soft-wrap.user.js
+++ b/github-soft-wrap.user.js
@@ -2,9 +2,11 @@
 // @name        Github soft-wrap toggler
 // @namespace   http://luiz.github.io
 // @description Adds a button "Soft-wrap" that toggles soft wrap on files and diffs shown on Github
-// @include     https://github.com/*
+// @author      https://github.com/luiz
 // @version     1
 // @grant       none
+// @include     https://github.com/*
+// @match       https://github.com/*
 // ==/UserScript==
 
 /*!
@@ -6741,41 +6743,19 @@ return jQuery;
 var jQuery212custom = $.noConflict(true);
 
 (function($) {
-	function toggleOnDiff(container) {
-		container.toggleClass("soft-wrap");
-	}
-	function toggleOnFile(container) {
-		var $pre = container.find("pre"),
-		$lines = $pre.find(".line");
-		if ($pre.css("white-space") == "pre") {
-			$pre.css("white-space", "pre-wrap");
-			$lines.css("height", "auto");
-		} else {
-			$pre.css("white-space", "pre");
-		}
-		$lines.each(function() {
-			var $line = $(this),
-			correspondingSpanId = "#" + $line.attr("id").replace("LC", "L");
-			$(correspondingSpanId).css("height", $line.css("height"));
-		});
-	}
-	$("<button>")
-	.addClass("minibutton", "soft-wrap")
+    $("<button>")
+	.addClass("btn btn-sm", "soft-wrap")
 	.text("Soft wrap")
-	.prependTo(".file:has(.file-code) .actions")
+    .prependTo(".file:has(table) .file-header .file-actions")
 	.click(function() {
 		var $this = $(this),
-		$fileContainer = $this.closest(".file");
-		if ($fileContainer.has("pre").length == 0) {
-			toggleOnDiff($fileContainer);
-		} else {
-			toggleOnFile($fileContainer);
-		}
+            $fileContainer = $this.closest(".file");
+		$fileContainer.find("table").toggleClass("soft-wrap");
 		$this.toggleClass("selected");
 	})
 	.each(function() {
 		var $this = $(this);
-		if ($this.closest(".file").is(".soft-wrap")) {
+		if ($this.closest(".file").find("table").is(".soft-wrap")) {
 			$this.addClass("selected");
 		}
 	});

--- a/github-soft-wrap.user.js
+++ b/github-soft-wrap.user.js
@@ -6743,19 +6743,42 @@ return jQuery;
 var jQuery212custom = $.noConflict(true);
 
 (function($) {
+	/**
+	 * Inspect the current `div.file` and return the proper child
+	 * object to which to apply the `soft-wrap` class.
+	 *
+	 * "Prose" documents toggle the .soft-wrap class at the
+	 * `div.file` level, but "code" documents must toggle at
+	 * the `div.file div.data table` level.
+	 */
+	function findWrappable(root) {
+		if (root.is(".file-type-prose")) {
+			return root;
+		} else {
+			return root.find("table");
+		}
+	}
+
+	/**
+	 * Create a new [Soft wrap] button, inject it into every
+	 * `div.file-actions` that isn't Markdown-rendered
+	 * (identified by having a <table>) and mark any `div.file`
+	 * that is already `.soft-wrap`ed as `.selected`.
+	 */
 	$("<button>")
 	.addClass("btn btn-sm", "soft-wrap")
 	.text("Soft wrap")
 	.prependTo(".file:has(table) .file-header .file-actions")
 	.click(function() {
 		var $this = $(this),
-			$fileContainer = $this.closest(".file");
-		$fileContainer.find("table").toggleClass("soft-wrap");
+			$fileContainer = findWrappable($this.closest(".file"));
+
+		$fileContainer.toggleClass("soft-wrap");
 		$this.toggleClass("selected");
 	})
 	.each(function() {
 		var $this = $(this);
-		if ($this.closest(".file").find("table").is(".soft-wrap")) {
+		if (findWrappable($this.closest(".file")).is(".soft-wrap")) {
 			$this.addClass("selected");
 		}
 	});

--- a/github-soft-wrap.user.js
+++ b/github-soft-wrap.user.js
@@ -6743,13 +6743,13 @@ return jQuery;
 var jQuery212custom = $.noConflict(true);
 
 (function($) {
-    $("<button>")
+	$("<button>")
 	.addClass("btn btn-sm", "soft-wrap")
 	.text("Soft wrap")
-    .prependTo(".file:has(table) .file-header .file-actions")
+	.prependTo(".file:has(table) .file-header .file-actions")
 	.click(function() {
 		var $this = $(this),
-            $fileContainer = $this.closest(".file");
+			$fileContainer = $this.closest(".file");
 		$fileContainer.find("table").toggleClass("soft-wrap");
 		$this.toggleClass("selected");
 	})


### PR DESCRIPTION
Github has updated their DOM and CSS, which unless I'm mistaken, simplifies this script's job considerably. However, in it's current state the script is broken-- there are no [Soft wrap] buttons displayed, since the targeted CSS selectors are no longer correct.

This PR simplifies the jQuery selectors and click logic to match Github's new DOM and the now-more-universally-available `soft-wrap` class. It updates the [Soft wrap] button's CSS to match Github's current presentation style.

Also adds a `@match` annotation, which seems to make recent Chrome versions happier, `@author` information and a note in the readme about Tampermonkey for Chrome users.

Please note that I didn't bump the version number, which may be called for in this instance.
